### PR TITLE
Added rudimentary support for cygwin

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -574,6 +574,10 @@ sub query_build {
 # PROTECTED API
 #-------------------------------------------------------------------------------
 
+sub is_cygwin {
+    return $^O eq "cygwin";
+}
+
 sub is_win32 {
     return $^O =~ /^MSWin32$/io;
 }
@@ -1129,6 +1133,13 @@ sub locate_lib_dir_and_file {
             $lib_dir = $dir;
         }
     }
+    elsif ($self->is_cygwin) {
+        if (-d ($dir = catdir($prefix_dir, 'lib')) and
+               ($lib_file, $lib_name) = $self->probe_for_lib_file($dir))
+        {
+           $lib_dir = $dir;
+        }
+    }
     if (not defined $lib_dir) {
         if (defined $Config{use64bitint} and
             $Config{use64bitint} eq 'define' and
@@ -1249,6 +1260,12 @@ sub probe_for_lib_file {
                 $lib_file = $file;
                 $lib_name = 'libcrypto';
             }
+        }
+    }
+    elsif ($self->is_cygwin) {
+         if (-f ($file = catfile($candidate_lib_dir, 'libcrypto.dll.a'))) {
+            $lib_file = $file;
+            $lib_name = 'crypto';
         }
     }
     else {


### PR DESCRIPTION
Fixes issue #3 on my machine:

```
$ perl Makefile.PL

Where is your OpenSSL? [/usr]

Found include directory ............ /usr/include
Found OpenSSL version .............. 1.1.1f
Found crypto library ............... /usr/lib/libcrypto.dll.a
Found binary executable ............ /usr/bin/openssl.exe

Cipher algorithms available:
  [ 1] DES block cipher
  [ 2] Two key triple DES block cipher
  [ 3] Three key triple DES block cipher
  [ 4] DESX block cipher
  [ 5] RC4 stream cipher
  [ 6] IDEA block cipher
  [ 7] RC2 block cipher
  [ 8] Blowfish block cipher
  [ 9] Null cipher
  [10] RC5 block cipher
  [11] CAST5 block cipher
  [12] AES block cipher
Which cipher algorithm do you want to use? [12]

Modes of operation available:
  [1] ECB (Electronic Codebook Mode)
  [2] CBC (Cipher Block Chaining Mode)
  [3] CFB (64-Bit Cipher Feedback Mode)
  [4] OFB (64-Bit Output Feedback Mode)
Which mode of operation do you want to use? [2]

This is a variable key length algorithm.
Valid key lengths are: 16, 24 or 32 bytes.
What key length (in bytes) do you want to use? [32]

You can either specify a password from which the key to be used for
encryption/decryption will be derived using a PKCS#5 key derivation
algorithm, or you can directly specify the key to use.
You can also have a password or key randomly generated for you.

Options for specifying or deriving the key:
  [1] Enter a password when prompted
  [2] Have a password randomly generated
  [3] Enter a key when prompted
  [4] Have a key randomly generated
How do you want to specify or derive the key? [2]

Random number generators:
  [1] Perl's built-in rand() function
  [2] OpenSSL's rand command
Which RNG do you want to use? [2]

Your cipher configuration has been written to the file 'CipherConfig.h'.
You may want to keep this file in a safe place if you ever need to rebuild
these modules using the same configuration, especially if your key was
randomly generated.

Build options:
  [1] Build both components
  [2] Build CryptFile component only
  [3] Build Decrypt component only
Which component(s) do you want to build? [1]

Do you want to install 'crypt_file'? [y]

Checking if your kit is complete...
Looks good
Writing MYMETA.yml and MYMETA.json
Writing MYMETA.yml and MYMETA.json
Generating a Unix-style Makefile
Writing Makefile for Filter::Crypto
Writing MYMETA.yml and MYMETA.json

$ make
cp lib/PAR/Filter/Crypto.pm blib/lib/PAR/Filter/Crypto.pm
cp lib/Filter/Crypto.pm blib/lib/Filter/Crypto.pm
make[1]: Entering directory '/home/hakon/perl/github/Filter-Crypto/CryptFile'
cp lib/Filter/Crypto/CryptFile.pm ../blib/lib/Filter/Crypto/CryptFile.pm
Running Mkbootstrap for CryptFile ()
chmod 644 "CryptFile.bs"
"/usr/bin/perl.exe" -MExtUtils::Command::MM -e 'cp_nonempty' -- CryptFile.bs ../blib/arch/auto/Filter/Crypto/CryptFile/CryptFile.bs 644
"/usr/bin/perl.exe" "/usr/share/perl5/5.30/ExtUtils/xsubpp"  -typemap '/usr/share/perl5/5.30/ExtUtils/typemap' -typemap '/home/hakon/perl/github/Filter-Crypto/CryptFile/typemap'  CryptFile.xs > CryptFile.xsc
mv CryptFile.xsc CryptFile.c
gcc -c  -I/usr/include -DPERL_USE_SAFE_PUTENV -U__STRICT_ANSI__ -D_GNU_SOURCE -ggdb -O2 -pipe -Wall -Werror=format-security -D_FORTIFY_SOURCE=2 -fstack-protector-strong --param=ssp-buffer-size=4 -fdebug-prefix-map=/mnt/share/cygpkgs/perl/perl.x86_64/build=/usr/src/debug/perl-5.30.3-1 -fdebug-prefix-map=/mnt/share/cygpkgs/perl/perl.x86_64/src/perl-5.30.3=/usr/src/debug/perl-5.30.3-1 -fwrapv -fno-strict-aliasing -DUSEIMPORTLIB -O3   -DVERSION=\"2.10\" -DXS_VERSION=\"2.10\"  "-I/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE"  -DFILTER_CRYPTO_OPENSSL_VERSION=1010106 CryptFile.c
In file included from CryptFile.xs:32:
../CryptoCommon-c.inc:20:37: warning: "/*" within comment [-Wcomment]
   20 | /* #define FILTER_CRYPTO_DEBUG_MODE /**/
      |
../CryptoCommon-c.inc:23:40: warning: "/*" within comment [-Wcomment]
   23 | /* #define FILTER_CRYPTO_NO_RAND_BYTES /**/
      |
In file included from CryptFile.xs:32:
../CryptoCommon-c.inc: In function ‘FilterCrypto_CryptoInitCipher’:
../CryptoCommon-c.inc:264:17: warning: ‘RAND_pseudo_bytes’ is deprecated [-Wdeprecated-declarations]
  264 |                 if (!RAND_pseudo_bytes(salt_text, ctx->required_salt_len)) {
      |                 ^~
In file included from /usr/include/openssl/e_os2.h:13,
                 from /usr/include/openssl/err.h:13,
                 from ../CryptoCommon-c.inc:42,
                 from CryptFile.xs:32:
/usr/include/openssl/rand.h:44:1: note: declared here
   44 | DEPRECATEDIN_1_1_0(int RAND_pseudo_bytes(unsigned char *buf, int num))
      | ^~~~~~~~~~~~~~~~~~
In file included from /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/perl.h:5359,
                 from ../CryptoCommon-c.inc:49,
                 from CryptFile.xs:32:
../CryptoCommon-c.inc:280:31: warning: pointer targets in passing argument 3 of ‘Perl_sv_catpvn_flags’ differ in signedness [-Wpointer-sign]
  280 |             sv_catpvn(out_sv, salt_text, ctx->required_salt_len);
      |                               ^~~~~~~~~
      |                               |
      |                               unsigned char *
/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/embed.h:740:63: note: in definition of macro ‘sv_catpvn_flags’
  740 | #define sv_catpvn_flags(a,b,c,d) Perl_sv_catpvn_flags(aTHX_ a,b,c,d)
      |                                                               ^
../CryptoCommon-c.inc:280:13: note: in expansion of macro ‘sv_catpvn’
  280 |             sv_catpvn(out_sv, salt_text, ctx->required_salt_len);
      |             ^~~~~~~~~
In file included from /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/perl.h:5320,
                 from ../CryptoCommon-c.inc:49,
                 from CryptFile.xs:32:
/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/proto.h:3279:75: note: expected ‘const char *’ but argument is of type ‘unsigned char *’
 3279 | PERL_CALLCONV void Perl_sv_catpvn_flags(pTHX_ SV *const dstr, const char *sstr, const STRLEN len, const I32 flags);
      |                                                               ~~~~~~~~~~~~^~~~
In file included from CryptFile.xs:32:
../CryptoCommon-c.inc:294:17: warning: ‘RAND_pseudo_bytes’ is deprecated [-Wdeprecated-declarations]
  294 |                 if (!RAND_pseudo_bytes(iv_text, ctx->required_iv_len)) {
      |                 ^~
In file included from /usr/include/openssl/e_os2.h:13,
                 from /usr/include/openssl/err.h:13,
                 from ../CryptoCommon-c.inc:42,
                 from CryptFile.xs:32:
/usr/include/openssl/rand.h:44:1: note: declared here
   44 | DEPRECATEDIN_1_1_0(int RAND_pseudo_bytes(unsigned char *buf, int num))
      | ^~~~~~~~~~~~~~~~~~
In file included from /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/perl.h:5359,
                 from ../CryptoCommon-c.inc:49,
                 from CryptFile.xs:32:
../CryptoCommon-c.inc:310:31: warning: pointer targets in passing argument 3 of ‘Perl_sv_catpvn_flags’ differ in signedness [-Wpointer-sign]
  310 |             sv_catpvn(out_sv, iv_text, ctx->required_iv_len);
      |                               ^~~~~~~
      |                               |
      |                               unsigned char *
/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/embed.h:740:63: note: in definition of macro ‘sv_catpvn_flags’
  740 | #define sv_catpvn_flags(a,b,c,d) Perl_sv_catpvn_flags(aTHX_ a,b,c,d)
      |                                                               ^
../CryptoCommon-c.inc:310:13: note: in expansion of macro ‘sv_catpvn’
  310 |             sv_catpvn(out_sv, iv_text, ctx->required_iv_len);
      |             ^~~~~~~~~
In file included from /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/perl.h:5320,
                 from ../CryptoCommon-c.inc:49,
                 from CryptFile.xs:32:
/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/proto.h:3279:75: note: expected ‘const char *’ but argument is of type ‘unsigned char *’
 3279 | PERL_CALLCONV void Perl_sv_catpvn_flags(pTHX_ SV *const dstr, const char *sstr, const STRLEN len, const I32 flags);
      |                                                               ~~~~~~~~~~~~^~~~
In file included from /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/perl.h:5359,
                 from ../CryptoCommon-c.inc:49,
                 from CryptFile.xs:32:
../CryptoCommon-c.inc:338:45: warning: pointer targets in passing argument 3 of ‘Perl_sv_catpvn_flags’ differ in signedness [-Wpointer-sign]
  338 |                     sv_catpvn(ctx->salt_sv, in_text, missing_salt_len);
      |                                             ^~~~~~~
      |                                             |
      |                                             const unsigned char *
/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/embed.h:740:63: note: in definition of macro ‘sv_catpvn_flags’
  740 | #define sv_catpvn_flags(a,b,c,d) Perl_sv_catpvn_flags(aTHX_ a,b,c,d)
      |                                                               ^
../CryptoCommon-c.inc:338:21: note: in expansion of macro ‘sv_catpvn’
  338 |                     sv_catpvn(ctx->salt_sv, in_text, missing_salt_len);
      |                     ^~~~~~~~~
In file included from /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/perl.h:5320,
                 from ../CryptoCommon-c.inc:49,
                 from CryptFile.xs:32:
/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/proto.h:3279:75: note: expected ‘const char *’ but argument is of type ‘const unsigned char *’
 3279 | PERL_CALLCONV void Perl_sv_catpvn_flags(pTHX_ SV *const dstr, const char *sstr, const STRLEN len, const I32 flags);
      |                                                               ~~~~~~~~~~~~^~~~
In file included from /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/perl.h:5359,
                 from ../CryptoCommon-c.inc:49,
                 from CryptFile.xs:32:
../CryptoCommon-c.inc:342:45: warning: pointer targets in passing argument 3 of ‘Perl_sv_catpvn_flags’ differ in signedness [-Wpointer-sign]
  342 |                     sv_catpvn(ctx->salt_sv, in_text, in_len);
      |                                             ^~~~~~~
      |                                             |
      |                                             const unsigned char *
/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/embed.h:740:63: note: in definition of macro ‘sv_catpvn_flags’
  740 | #define sv_catpvn_flags(a,b,c,d) Perl_sv_catpvn_flags(aTHX_ a,b,c,d)
      |                                                               ^
../CryptoCommon-c.inc:342:21: note: in expansion of macro ‘sv_catpvn’
  342 |                     sv_catpvn(ctx->salt_sv, in_text, in_len);
      |                     ^~~~~~~~~
In file included from /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/perl.h:5320,
                 from ../CryptoCommon-c.inc:49,
                 from CryptFile.xs:32:
/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/proto.h:3279:75: note: expected ‘const char *’ but argument is of type ‘const unsigned char *’
 3279 | PERL_CALLCONV void Perl_sv_catpvn_flags(pTHX_ SV *const dstr, const char *sstr, const STRLEN len, const I32 flags);
      |                                                               ~~~~~~~~~~~~^~~~
In file included from /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/perl.h:5359,
                 from ../CryptoCommon-c.inc:49,
                 from CryptFile.xs:32:
../CryptoCommon-c.inc:364:43: warning: pointer targets in passing argument 3 of ‘Perl_sv_catpvn_flags’ differ in signedness [-Wpointer-sign]
  364 |                     sv_catpvn(ctx->iv_sv, in_text, missing_iv_len);
      |                                           ^~~~~~~
      |                                           |
      |                                           const unsigned char *
/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/embed.h:740:63: note: in definition of macro ‘sv_catpvn_flags’
  740 | #define sv_catpvn_flags(a,b,c,d) Perl_sv_catpvn_flags(aTHX_ a,b,c,d)
      |                                                               ^
../CryptoCommon-c.inc:364:21: note: in expansion of macro ‘sv_catpvn’
  364 |                     sv_catpvn(ctx->iv_sv, in_text, missing_iv_len);
      |                     ^~~~~~~~~
In file included from /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/perl.h:5320,
                 from ../CryptoCommon-c.inc:49,
                 from CryptFile.xs:32:
/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/proto.h:3279:75: note: expected ‘const char *’ but argument is of type ‘const unsigned char *’
 3279 | PERL_CALLCONV void Perl_sv_catpvn_flags(pTHX_ SV *const dstr, const char *sstr, const STRLEN len, const I32 flags);
      |                                                               ~~~~~~~~~~~~^~~~
In file included from /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/perl.h:5359,
                 from ../CryptoCommon-c.inc:49,
                 from CryptFile.xs:32:
../CryptoCommon-c.inc:368:43: warning: pointer targets in passing argument 3 of ‘Perl_sv_catpvn_flags’ differ in signedness [-Wpointer-sign]
  368 |                     sv_catpvn(ctx->iv_sv, in_text, in_len);
      |                                           ^~~~~~~
      |                                           |
      |                                           const unsigned char *
/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/embed.h:740:63: note: in definition of macro ‘sv_catpvn_flags’
  740 | #define sv_catpvn_flags(a,b,c,d) Perl_sv_catpvn_flags(aTHX_ a,b,c,d)
      |                                                               ^
../CryptoCommon-c.inc:368:21: note: in expansion of macro ‘sv_catpvn’
  368 |                     sv_catpvn(ctx->iv_sv, in_text, in_len);
      |                     ^~~~~~~~~
In file included from /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/perl.h:5320,
                 from ../CryptoCommon-c.inc:49,
                 from CryptFile.xs:32:
/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/proto.h:3279:75: note: expected ‘const char *’ but argument is of type ‘const unsigned char *’
 3279 | PERL_CALLCONV void Perl_sv_catpvn_flags(pTHX_ SV *const dstr, const char *sstr, const STRLEN len, const I32 flags);
      |                                                               ~~~~~~~~~~~~^~~~
In file included from CryptFile.xs:32:
../CryptoCommon-c.inc: In function ‘FilterCrypto_CipherInit’:
../CryptoCommon-c.inc:585:32: warning: pointer targets in passing argument 1 of ‘PKCS5_PBKDF2_HMAC_SHA1’ differ in signedness [-Wpointer-sign]
  585 |     if (PKCS5_PBKDF2_HMAC_SHA1(filter_crypto_pswd, sizeof(filter_crypto_pswd),
      |                                ^~~~~~~~~~~~~~~~~~
      |                                |
      |                                const unsigned char *
In file included from ../CryptoCommon-c.inc:43,
                 from CryptFile.xs:32:
/usr/include/openssl/evp.h:1087:40: note: expected ‘const char *’ but argument is of type ‘const unsigned char *’
 1087 | int PKCS5_PBKDF2_HMAC_SHA1(const char *pass, int passlen,
      |                            ~~~~~~~~~~~~^~~~
In file included from /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/perl.h:2508,
                 from ../CryptoCommon-c.inc:49,
                 from CryptFile.xs:32:
CryptFile.xs: In function ‘FilterCrypto_CryptFh’:
CryptFile.xs:162:37: warning: pointer targets in passing argument 1 of ‘strncmp’ differ in signedness [-Wpointer-sign]
  162 |     if (in_len == use_len && strnEQ(in_text, filter_crypto_use_text, use_len)) {
      |                                     ^~~~~~~
      |                                     |
      |                                     unsigned char *
/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/handy.h:508:34: note: in definition of macro ‘strnEQ’
  508 | #define strnEQ(s1,s2,l) (strncmp(s1,s2,l) == 0)
      |                                  ^~
In file included from CryptFile.xs:30:
/usr/include/string.h:43:15: note: expected ‘const char *’ but argument is of type ‘unsigned char *’
   43 | int  strncmp (const char *, const char *, size_t);
      |               ^~~~~~~~~~~~
./../CryptoCommon-xs.inc: In function ‘XS_Filter__Crypto__CryptFile_DESTROY’:
./../CryptoCommon-xs.inc:80:9: warning: ‘ERR_remove_state’ is deprecated [-Wdeprecated-declarations]
   80 |         ERR_remove_state(0);
      |         ^~~~~~~~~~~~~~~~
In file included from /usr/include/openssl/e_os2.h:13,
                 from /usr/include/openssl/err.h:13,
                 from ../CryptoCommon-c.inc:42,
                 from CryptFile.xs:32:
/usr/include/openssl/err.h:261:1: note: declared here
  261 | DEPRECATEDIN_1_0_0(void ERR_remove_state(unsigned long pid))
      | ^~~~~~~~~~~~~~~~~~
CryptFile.c:646:7: warning: unused variable ‘self’ [-Wunused-variable]
  646 |  SV * self = ST(0)
      |       ^~~~
In file included from /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/perl.h:28,
                 from ../CryptoCommon-c.inc:49,
                 from CryptFile.xs:32:
At top level:
../ppport.h:3338:26: warning: ‘DPPP_dummy_PL_parser’ defined but not used [-Wunused-variable]
 3338 | #  define DPPP_NAMESPACE DPPP_
      |                          ^~~~~
/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/config.h:1385:27: note: in definition of macro ‘PeRl_CaTiFy’
 1385 | #define PeRl_CaTiFy(a, b) a ## b
      |                           ^
../ppport.h:3341:24: note: in expansion of macro ‘CAT2’
 3341 | #define DPPP_CAT2(x,y) CAT2(x,y)
      |                        ^~~~
../ppport.h:3342:21: note: in expansion of macro ‘DPPP_CAT2’
 3342 | #define DPPP_(name) DPPP_CAT2(DPPP_NAMESPACE, name)
      |                     ^~~~~~~~~
../ppport.h:3342:31: note: in expansion of macro ‘DPPP_NAMESPACE’
 3342 | #define DPPP_(name) DPPP_CAT2(DPPP_NAMESPACE, name)
      |                               ^~~~~~~~~~~~~~
../ppport.h:4337:18: note: in expansion of macro ‘DPPP_’
 4337 | static yy_parser DPPP_(dummy_PL_parser);
      |                  ^~~~~
In file included from /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/perl.h:3679,
                 from ../CryptoCommon-c.inc:49,
                 from CryptFile.xs:32:
CryptFile.xs: In function ‘FilterCrypto_CryptFh’:
/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/sv.h:333:23: warning: ‘buf_sv’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  333 | #define SvANY(sv) (sv)->sv_any
      |                       ^~
CryptFile.xs:123:9: note: ‘buf_sv’ was declared here
  123 |     SV *buf_sv;
      |         ^~~~~~
rm -f ../blib/arch/auto/Filter/Crypto/CryptFile/CryptFile.dll
g++  --shared  -Wl,--enable-auto-import -Wl,--export-all-symbols -Wl,--enable-auto-image-base -fstack-protector-strong  CryptFile.o  -o ../blib/arch/auto/Filter/Crypto/CryptFile/CryptFile.dll  \
  /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/cygperl5_30.dll -L/usr/lib -lcrypto   \

chmod 755 ../blib/arch/auto/Filter/Crypto/CryptFile/CryptFile.dll
Manifying 1 pod document
make[1]: Leaving directory '/home/hakon/perl/github/Filter-Crypto/CryptFile'
make[1]: Entering directory '/home/hakon/perl/github/Filter-Crypto/Decrypt'
cp lib/Filter/Crypto/Decrypt.pm ../blib/lib/Filter/Crypto/Decrypt.pm
Running Mkbootstrap for Decrypt ()
chmod 644 "Decrypt.bs"
"/usr/bin/perl.exe" -MExtUtils::Command::MM -e 'cp_nonempty' -- Decrypt.bs ../blib/arch/auto/Filter/Crypto/Decrypt/Decrypt.bs 644
"/usr/bin/perl.exe" "/usr/share/perl5/5.30/ExtUtils/xsubpp"  -typemap '/usr/share/perl5/5.30/ExtUtils/typemap'  Decrypt.xs > Decrypt.xsc
mv Decrypt.xsc Decrypt.c
gcc -c  -I/usr/include -DPERL_USE_SAFE_PUTENV -U__STRICT_ANSI__ -D_GNU_SOURCE -ggdb -O2 -pipe -Wall -Werror=format-security -D_FORTIFY_SOURCE=2 -fstack-protector-strong --param=ssp-buffer-size=4 -fdebug-prefix-map=/mnt/share/cygpkgs/perl/perl.x86_64/build=/usr/src/debug/perl-5.30.3-1 -fdebug-prefix-map=/mnt/share/cygpkgs/perl/perl.x86_64/src/perl-5.30.3=/usr/src/debug/perl-5.30.3-1 -fwrapv -fno-strict-aliasing -DUSEIMPORTLIB -O3   -DVERSION=\"2.10\" -DXS_VERSION=\"2.10\"  "-I/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE"  -DFILTER_CRYPTO_OPENSSL_VERSION=1010106 Decrypt.c
In file included from Decrypt.xs:23:
../CryptoCommon-c.inc:20:37: warning: "/*" within comment [-Wcomment]
   20 | /* #define FILTER_CRYPTO_DEBUG_MODE /**/
      |
../CryptoCommon-c.inc:23:40: warning: "/*" within comment [-Wcomment]
   23 | /* #define FILTER_CRYPTO_NO_RAND_BYTES /**/
      |
In file included from Decrypt.xs:23:
../CryptoCommon-c.inc: In function ‘FilterCrypto_CryptoInitCipher’:
../CryptoCommon-c.inc:264:17: warning: ‘RAND_pseudo_bytes’ is deprecated [-Wdeprecated-declarations]
  264 |                 if (!RAND_pseudo_bytes(salt_text, ctx->required_salt_len)) {
      |                 ^~
In file included from /usr/include/openssl/e_os2.h:13,
                 from /usr/include/openssl/err.h:13,
                 from ../CryptoCommon-c.inc:42,
                 from Decrypt.xs:23:
/usr/include/openssl/rand.h:44:1: note: declared here
   44 | DEPRECATEDIN_1_1_0(int RAND_pseudo_bytes(unsigned char *buf, int num))
      | ^~~~~~~~~~~~~~~~~~
In file included from /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/perl.h:5359,
                 from ../CryptoCommon-c.inc:49,
                 from Decrypt.xs:23:
../CryptoCommon-c.inc:280:31: warning: pointer targets in passing argument 3 of ‘Perl_sv_catpvn_flags’ differ in signedness [-Wpointer-sign]
  280 |             sv_catpvn(out_sv, salt_text, ctx->required_salt_len);
      |                               ^~~~~~~~~
      |                               |
      |                               unsigned char *
/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/embed.h:740:63: note: in definition of macro ‘sv_catpvn_flags’
  740 | #define sv_catpvn_flags(a,b,c,d) Perl_sv_catpvn_flags(aTHX_ a,b,c,d)
      |                                                               ^
../CryptoCommon-c.inc:280:13: note: in expansion of macro ‘sv_catpvn’
  280 |             sv_catpvn(out_sv, salt_text, ctx->required_salt_len);
      |             ^~~~~~~~~
In file included from /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/perl.h:5320,
                 from ../CryptoCommon-c.inc:49,
                 from Decrypt.xs:23:
/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/proto.h:3279:75: note: expected ‘const char *’ but argument is of type ‘unsigned char *’
 3279 | PERL_CALLCONV void Perl_sv_catpvn_flags(pTHX_ SV *const dstr, const char *sstr, const STRLEN len, const I32 flags);
      |                                                               ~~~~~~~~~~~~^~~~
In file included from Decrypt.xs:23:
../CryptoCommon-c.inc:294:17: warning: ‘RAND_pseudo_bytes’ is deprecated [-Wdeprecated-declarations]
  294 |                 if (!RAND_pseudo_bytes(iv_text, ctx->required_iv_len)) {
      |                 ^~
In file included from /usr/include/openssl/e_os2.h:13,
                 from /usr/include/openssl/err.h:13,
                 from ../CryptoCommon-c.inc:42,
                 from Decrypt.xs:23:
/usr/include/openssl/rand.h:44:1: note: declared here
   44 | DEPRECATEDIN_1_1_0(int RAND_pseudo_bytes(unsigned char *buf, int num))
      | ^~~~~~~~~~~~~~~~~~
In file included from /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/perl.h:5359,
                 from ../CryptoCommon-c.inc:49,
                 from Decrypt.xs:23:
../CryptoCommon-c.inc:310:31: warning: pointer targets in passing argument 3 of ‘Perl_sv_catpvn_flags’ differ in signedness [-Wpointer-sign]
  310 |             sv_catpvn(out_sv, iv_text, ctx->required_iv_len);
      |                               ^~~~~~~
      |                               |
      |                               unsigned char *
/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/embed.h:740:63: note: in definition of macro ‘sv_catpvn_flags’
  740 | #define sv_catpvn_flags(a,b,c,d) Perl_sv_catpvn_flags(aTHX_ a,b,c,d)
      |                                                               ^
../CryptoCommon-c.inc:310:13: note: in expansion of macro ‘sv_catpvn’
  310 |             sv_catpvn(out_sv, iv_text, ctx->required_iv_len);
      |             ^~~~~~~~~
In file included from /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/perl.h:5320,
                 from ../CryptoCommon-c.inc:49,
                 from Decrypt.xs:23:
/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/proto.h:3279:75: note: expected ‘const char *’ but argument is of type ‘unsigned char *’
 3279 | PERL_CALLCONV void Perl_sv_catpvn_flags(pTHX_ SV *const dstr, const char *sstr, const STRLEN len, const I32 flags);
      |                                                               ~~~~~~~~~~~~^~~~
In file included from /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/perl.h:5359,
                 from ../CryptoCommon-c.inc:49,
                 from Decrypt.xs:23:
../CryptoCommon-c.inc:338:45: warning: pointer targets in passing argument 3 of ‘Perl_sv_catpvn_flags’ differ in signedness [-Wpointer-sign]
  338 |                     sv_catpvn(ctx->salt_sv, in_text, missing_salt_len);
      |                                             ^~~~~~~
      |                                             |
      |                                             const unsigned char *
/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/embed.h:740:63: note: in definition of macro ‘sv_catpvn_flags’
  740 | #define sv_catpvn_flags(a,b,c,d) Perl_sv_catpvn_flags(aTHX_ a,b,c,d)
      |                                                               ^
../CryptoCommon-c.inc:338:21: note: in expansion of macro ‘sv_catpvn’
  338 |                     sv_catpvn(ctx->salt_sv, in_text, missing_salt_len);
      |                     ^~~~~~~~~
In file included from /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/perl.h:5320,
                 from ../CryptoCommon-c.inc:49,
                 from Decrypt.xs:23:
/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/proto.h:3279:75: note: expected ‘const char *’ but argument is of type ‘const unsigned char *’
 3279 | PERL_CALLCONV void Perl_sv_catpvn_flags(pTHX_ SV *const dstr, const char *sstr, const STRLEN len, const I32 flags);
      |                                                               ~~~~~~~~~~~~^~~~
In file included from /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/perl.h:5359,
                 from ../CryptoCommon-c.inc:49,
                 from Decrypt.xs:23:
../CryptoCommon-c.inc:342:45: warning: pointer targets in passing argument 3 of ‘Perl_sv_catpvn_flags’ differ in signedness [-Wpointer-sign]
  342 |                     sv_catpvn(ctx->salt_sv, in_text, in_len);
      |                                             ^~~~~~~
      |                                             |
      |                                             const unsigned char *
/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/embed.h:740:63: note: in definition of macro ‘sv_catpvn_flags’
  740 | #define sv_catpvn_flags(a,b,c,d) Perl_sv_catpvn_flags(aTHX_ a,b,c,d)
      |                                                               ^
../CryptoCommon-c.inc:342:21: note: in expansion of macro ‘sv_catpvn’
  342 |                     sv_catpvn(ctx->salt_sv, in_text, in_len);
      |                     ^~~~~~~~~
In file included from /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/perl.h:5320,
                 from ../CryptoCommon-c.inc:49,
                 from Decrypt.xs:23:
/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/proto.h:3279:75: note: expected ‘const char *’ but argument is of type ‘const unsigned char *’
 3279 | PERL_CALLCONV void Perl_sv_catpvn_flags(pTHX_ SV *const dstr, const char *sstr, const STRLEN len, const I32 flags);
      |                                                               ~~~~~~~~~~~~^~~~
In file included from /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/perl.h:5359,
                 from ../CryptoCommon-c.inc:49,
                 from Decrypt.xs:23:
../CryptoCommon-c.inc:364:43: warning: pointer targets in passing argument 3 of ‘Perl_sv_catpvn_flags’ differ in signedness [-Wpointer-sign]
  364 |                     sv_catpvn(ctx->iv_sv, in_text, missing_iv_len);
      |                                           ^~~~~~~
      |                                           |
      |                                           const unsigned char *
/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/embed.h:740:63: note: in definition of macro ‘sv_catpvn_flags’
  740 | #define sv_catpvn_flags(a,b,c,d) Perl_sv_catpvn_flags(aTHX_ a,b,c,d)
      |                                                               ^
../CryptoCommon-c.inc:364:21: note: in expansion of macro ‘sv_catpvn’
  364 |                     sv_catpvn(ctx->iv_sv, in_text, missing_iv_len);
      |                     ^~~~~~~~~
In file included from /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/perl.h:5320,
                 from ../CryptoCommon-c.inc:49,
                 from Decrypt.xs:23:
/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/proto.h:3279:75: note: expected ‘const char *’ but argument is of type ‘const unsigned char *’
 3279 | PERL_CALLCONV void Perl_sv_catpvn_flags(pTHX_ SV *const dstr, const char *sstr, const STRLEN len, const I32 flags);
      |                                                               ~~~~~~~~~~~~^~~~
In file included from /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/perl.h:5359,
                 from ../CryptoCommon-c.inc:49,
                 from Decrypt.xs:23:
../CryptoCommon-c.inc:368:43: warning: pointer targets in passing argument 3 of ‘Perl_sv_catpvn_flags’ differ in signedness [-Wpointer-sign]
  368 |                     sv_catpvn(ctx->iv_sv, in_text, in_len);
      |                                           ^~~~~~~
      |                                           |
      |                                           const unsigned char *
/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/embed.h:740:63: note: in definition of macro ‘sv_catpvn_flags’
  740 | #define sv_catpvn_flags(a,b,c,d) Perl_sv_catpvn_flags(aTHX_ a,b,c,d)
      |                                                               ^
../CryptoCommon-c.inc:368:21: note: in expansion of macro ‘sv_catpvn’
  368 |                     sv_catpvn(ctx->iv_sv, in_text, in_len);
      |                     ^~~~~~~~~
In file included from /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/perl.h:5320,
                 from ../CryptoCommon-c.inc:49,
                 from Decrypt.xs:23:
/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/proto.h:3279:75: note: expected ‘const char *’ but argument is of type ‘const unsigned char *’
 3279 | PERL_CALLCONV void Perl_sv_catpvn_flags(pTHX_ SV *const dstr, const char *sstr, const STRLEN len, const I32 flags);
      |                                                               ~~~~~~~~~~~~^~~~
In file included from Decrypt.xs:23:
../CryptoCommon-c.inc: In function ‘FilterCrypto_CipherInit’:
../CryptoCommon-c.inc:585:32: warning: pointer targets in passing argument 1 of ‘PKCS5_PBKDF2_HMAC_SHA1’ differ in signedness [-Wpointer-sign]
  585 |     if (PKCS5_PBKDF2_HMAC_SHA1(filter_crypto_pswd, sizeof(filter_crypto_pswd),
      |                                ^~~~~~~~~~~~~~~~~~
      |                                |
      |                                const unsigned char *
In file included from ../CryptoCommon-c.inc:43,
                 from Decrypt.xs:23:
/usr/include/openssl/evp.h:1087:40: note: expected ‘const char *’ but argument is of type ‘const unsigned char *’
 1087 | int PKCS5_PBKDF2_HMAC_SHA1(const char *pass, int passlen,
      |                            ~~~~~~~~~~~~^~~~
In file included from /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/perl.h:5359,
                 from ../CryptoCommon-c.inc:49,
                 from Decrypt.xs:23:
Decrypt.xs: In function ‘FilterCrypto_FilterDecrypt’:
Decrypt.xs:310:35: warning: pointer targets in passing argument 3 of ‘Perl_sv_catpvn_flags’ differ in signedness [-Wpointer-sign]
  310 |                 sv_catpvn(buf_sv, out_ptr, num_bytes);
      |                                   ^~~~~~~
      |                                   |
      |                                   const unsigned char *
/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/embed.h:740:63: note: in definition of macro ‘sv_catpvn_flags’
  740 | #define sv_catpvn_flags(a,b,c,d) Perl_sv_catpvn_flags(aTHX_ a,b,c,d)
      |                                                               ^
Decrypt.xs:310:17: note: in expansion of macro ‘sv_catpvn’
  310 |                 sv_catpvn(buf_sv, out_ptr, num_bytes);
      |                 ^~~~~~~~~
In file included from /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/perl.h:5320,
                 from ../CryptoCommon-c.inc:49,
                 from Decrypt.xs:23:
/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/proto.h:3279:75: note: expected ‘const char *’ but argument is of type ‘const unsigned char *’
 3279 | PERL_CALLCONV void Perl_sv_catpvn_flags(pTHX_ SV *const dstr, const char *sstr, const STRLEN len, const I32 flags);
      |                                                               ~~~~~~~~~~~~^~~~
In file included from /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/perl.h:5359,
                 from ../CryptoCommon-c.inc:49,
                 from Decrypt.xs:23:
Decrypt.xs:341:39: warning: pointer targets in passing argument 3 of ‘Perl_sv_catpvn_flags’ differ in signedness [-Wpointer-sign]
  341 |                     sv_catpvn(buf_sv, out_ptr, num_bytes);
      |                                       ^~~~~~~
      |                                       |
      |                                       const unsigned char *
/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/embed.h:740:63: note: in definition of macro ‘sv_catpvn_flags’
  740 | #define sv_catpvn_flags(a,b,c,d) Perl_sv_catpvn_flags(aTHX_ a,b,c,d)
      |                                                               ^
Decrypt.xs:341:21: note: in expansion of macro ‘sv_catpvn’
  341 |                     sv_catpvn(buf_sv, out_ptr, num_bytes);
      |                     ^~~~~~~~~
In file included from /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/perl.h:5320,
                 from ../CryptoCommon-c.inc:49,
                 from Decrypt.xs:23:
/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/proto.h:3279:75: note: expected ‘const char *’ but argument is of type ‘const unsigned char *’
 3279 | PERL_CALLCONV void Perl_sv_catpvn_flags(pTHX_ SV *const dstr, const char *sstr, const STRLEN len, const I32 flags);
      |                                                               ~~~~~~~~~~~~^~~~
In file included from /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/perl.h:5359,
                 from ../CryptoCommon-c.inc:49,
                 from Decrypt.xs:23:
Decrypt.xs:363:39: warning: pointer targets in passing argument 3 of ‘Perl_sv_catpvn_flags’ differ in signedness [-Wpointer-sign]
  363 |                     sv_catpvn(buf_sv, out_ptr, num_bytes);
      |                                       ^~~~~~~
      |                                       |
      |                                       const unsigned char *
/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/embed.h:740:63: note: in definition of macro ‘sv_catpvn_flags’
  740 | #define sv_catpvn_flags(a,b,c,d) Perl_sv_catpvn_flags(aTHX_ a,b,c,d)
      |                                                               ^
Decrypt.xs:363:21: note: in expansion of macro ‘sv_catpvn’
  363 |                     sv_catpvn(buf_sv, out_ptr, num_bytes);
      |                     ^~~~~~~~~
In file included from /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/perl.h:5320,
                 from ../CryptoCommon-c.inc:49,
                 from Decrypt.xs:23:
/usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/proto.h:3279:75: note: expected ‘const char *’ but argument is of type ‘const unsigned char *’
 3279 | PERL_CALLCONV void Perl_sv_catpvn_flags(pTHX_ SV *const dstr, const char *sstr, const STRLEN len, const I32 flags);
      |                                                               ~~~~~~~~~~~~^~~~
./../CryptoCommon-xs.inc: In function ‘XS_Filter__Crypto__Decrypt_DESTROY’:
./../CryptoCommon-xs.inc:80:9: warning: ‘ERR_remove_state’ is deprecated [-Wdeprecated-declarations]
   80 |         ERR_remove_state(0);
      |         ^~~~~~~~~~~~~~~~
In file included from /usr/include/openssl/e_os2.h:13,
                 from /usr/include/openssl/err.h:13,
                 from ../CryptoCommon-c.inc:42,
                 from Decrypt.xs:23:
/usr/include/openssl/err.h:261:1: note: declared here
  261 | DEPRECATEDIN_1_0_0(void ERR_remove_state(unsigned long pid))
      | ^~~~~~~~~~~~~~~~~~
Decrypt.c:659:7: warning: unused variable ‘self’ [-Wunused-variable]
  659 |  SV * self = ST(0)
      |       ^~~~
Decrypt.c: In function ‘XS_Filter__Crypto__Decrypt_import’:
Decrypt.c:699:7: warning: unused variable ‘module’ [-Wunused-variable]
  699 |  SV * module = ST(0)
      |       ^~~~~~
In file included from Decrypt.xs:23:
At top level:
../CryptoCommon-c.inc:852:13: warning: ‘FilterCrypto_EncodeSV’ defined but not used [-Wunused-function]
  852 | static void FilterCrypto_EncodeSV(pTHX_ const SV *in_sv, SV *out_sv)
      |             ^~~~~~~~~~~~~~~~~~~~~
rm -f ../blib/arch/auto/Filter/Crypto/Decrypt/Decrypt.dll
g++  --shared  -Wl,--enable-auto-import -Wl,--export-all-symbols -Wl,--enable-auto-image-base -fstack-protector-strong  Decrypt.o  -o ../blib/arch/auto/Filter/Crypto/Decrypt/Decrypt.dll  \
  /usr/lib/perl5/5.30/x86_64-cygwin-threads/CORE/cygperl5_30.dll -L/usr/lib -lcrypto   \

chmod 755 ../blib/arch/auto/Filter/Crypto/Decrypt/Decrypt.dll
Manifying 1 pod document
make[1]: Leaving directory '/home/hakon/perl/github/Filter-Crypto/Decrypt'
cp script/crypt_file blib/script/crypt_file
"/usr/bin/perl.exe" -MExtUtils::MY -e 'MY->fixin(shift)' -- blib/script/crypt_file
Manifying 1 pod document
Manifying 2 pod documents


```